### PR TITLE
Support for Neos 5+

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml
+# Editor-based HTTP Client requests
+/httpRequests/

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="NeosPluginSettings">
+    <option name="pluginEnabled" value="true" />
+  </component>
+  <component name="ProjectRootManager">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/neos_mautic.iml" filepath="$PROJECT_DIR$/.idea/neos_mautic.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/neos_mautic.iml
+++ b/.idea/neos_mautic.iml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/Classes" isTestSource="false" packagePrefix="PunktDe\Mautic\" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/php.xml
+++ b/.idea/php.xml
@@ -1,0 +1,174 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="PhpInterpreters">
+    <interpreters>
+      <interpreter id="976c2fab-1559-4545-b3be-4bfb8d558781" name="web" home="docker-compose://DATA" debugger_id="php.debugger.XDebug">
+        <remote_data INTERPRETER_PATH="php" HELPERS_PATH="/opt/.phpstorm_helpers" INITIALIZED="false" VALID="true" RUN_AS_ROOT_VIA_SUDO="false" DOCKER_ACCOUNT_NAME="Docker" DOCKER_COMPOSE_SERVICE_NAME="web" DOCKER_REMOTE_PROJECT_PATH="/opt/project">
+          <type_data command="EXEC" />
+          <dockerComposeConfigurationPaths>
+            <item value="$PROJECT_DIR$/../neos/docker-compose.yml" />
+          </dockerComposeConfigurationPaths>
+          <envs />
+        </remote_data>
+      </interpreter>
+    </interpreters>
+  </component>
+  <component name="PhpInterpretersPhpInfoCache">
+    <phpInfoCache>
+      <interpreter name="web">
+        <phpinfo binary_type="PHP" php_cli="/usr/local/bin/php" path_separator=":" version="7.4.11">
+          <additional_php_ini>/usr/local/etc/php/conf.d/allow_url_include.ini, /usr/local/etc/php/conf.d/date_timezone.ini, /usr/local/etc/php/conf.d/docker-php-ext-exif.ini, /usr/local/etc/php/conf.d/docker-php-ext-gd.ini, /usr/local/etc/php/conf.d/docker-php-ext-intl.ini, /usr/local/etc/php/conf.d/docker-php-ext-opcache.ini, /usr/local/etc/php/conf.d/docker-php-ext-pdo_mysql.ini, /usr/local/etc/php/conf.d/docker-php-ext-redis.ini, /usr/local/etc/php/conf.d/docker-php-ext-sodium.ini, /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini, /usr/local/etc/php/conf.d/docker-php-ext-yaml.ini, /usr/local/etc/php/conf.d/max_execution_time.ini, /usr/local/etc/php/conf.d/max_input_vars.ini, /usr/local/etc/php/conf.d/memory_limit.ini, /usr/local/etc/php/conf.d/post_max_size.ini, /usr/local/etc/php/conf.d/upload_max_filesize.ini, /usr/local/etc/php/conf.d/z_docker-upload.ini</additional_php_ini>
+          <configuration_file />
+          <configuration_options>
+            <configuration_option name="include_path" value=".:/usr/local/lib/php" />
+          </configuration_options>
+          <debuggers>
+            <debugger_info debugger="xdebug" debugger_version="2.9.4">
+              <debug_extensions />
+            </debugger_info>
+          </debuggers>
+          <loaded_extensions>
+            <extension name="Core" />
+            <extension name="PDO" />
+            <extension name="Phar" />
+            <extension name="Reflection" />
+            <extension name="SPL" />
+            <extension name="SimpleXML" />
+            <extension name="Zend OPcache" />
+            <extension name="ctype" />
+            <extension name="curl" />
+            <extension name="date" />
+            <extension name="dom" />
+            <extension name="exif" />
+            <extension name="fileinfo" />
+            <extension name="filter" />
+            <extension name="ftp" />
+            <extension name="gd" />
+            <extension name="hash" />
+            <extension name="iconv" />
+            <extension name="intl" />
+            <extension name="json" />
+            <extension name="libxml" />
+            <extension name="mbstring" />
+            <extension name="mysqlnd" />
+            <extension name="openssl" />
+            <extension name="pcre" />
+            <extension name="pdo_mysql" />
+            <extension name="pdo_sqlite" />
+            <extension name="posix" />
+            <extension name="readline" />
+            <extension name="redis" />
+            <extension name="session" />
+            <extension name="sodium" />
+            <extension name="sqlite3" />
+            <extension name="standard" />
+            <extension name="tokenizer" />
+            <extension name="xdebug" />
+            <extension name="xml" />
+            <extension name="xmlreader" />
+            <extension name="xmlwriter" />
+            <extension name="yaml" />
+            <extension name="zlib" />
+          </loaded_extensions>
+        </phpinfo>
+      </interpreter>
+    </phpInfoCache>
+  </component>
+  <component name="PhpProjectSharedConfiguration" php_language_level="7.1" />
+  <component name="PhpRuntimeConfiguration">
+    <extensions>
+      <extension name="Ev" enabled="false" />
+      <extension name="SQLite" enabled="false" />
+      <extension name="SplType" enabled="false" />
+      <extension name="ZendDebugger" enabled="false" />
+      <extension name="ZendUtils" enabled="false" />
+      <extension name="amqp" enabled="false" />
+      <extension name="apache" enabled="false" />
+      <extension name="apcu" enabled="false" />
+      <extension name="bcmath" enabled="false" />
+      <extension name="bz2" enabled="false" />
+      <extension name="calendar" enabled="false" />
+      <extension name="cassandra" enabled="false" />
+      <extension name="couchbase" enabled="false" />
+      <extension name="cubrid" enabled="false" />
+      <extension name="dba" enabled="false" />
+      <extension name="decimal" enabled="false" />
+      <extension name="dio" enabled="false" />
+      <extension name="enchant" enabled="false" />
+      <extension name="fann" enabled="false" />
+      <extension name="ffmpeg" enabled="false" />
+      <extension name="gearman" enabled="false" />
+      <extension name="geoip" enabled="false" />
+      <extension name="geos" enabled="false" />
+      <extension name="gettext" enabled="false" />
+      <extension name="gmagick" enabled="false" />
+      <extension name="gmp" enabled="false" />
+      <extension name="gnupg" enabled="false" />
+      <extension name="grpc" enabled="false" />
+      <extension name="http" enabled="false" />
+      <extension name="ibm_db2" enabled="false" />
+      <extension name="igbinary" enabled="false" />
+      <extension name="imagick" enabled="false" />
+      <extension name="imap" enabled="false" />
+      <extension name="inotify" enabled="false" />
+      <extension name="interbase" enabled="false" />
+      <extension name="judy" enabled="false" />
+      <extension name="ldap" enabled="false" />
+      <extension name="libevent" enabled="false" />
+      <extension name="libsodium" enabled="false" />
+      <extension name="mailparse" enabled="false" />
+      <extension name="mcrypt" enabled="false" />
+      <extension name="memcache" enabled="false" />
+      <extension name="memcached" enabled="false" />
+      <extension name="ming" enabled="false" />
+      <extension name="mongo" enabled="false" />
+      <extension name="mongodb" enabled="false" />
+      <extension name="mosquitto-php" enabled="false" />
+      <extension name="mqseries" enabled="false" />
+      <extension name="mssql" enabled="false" />
+      <extension name="mysql" enabled="false" />
+      <extension name="mysql_xdevapi" enabled="false" />
+      <extension name="mysqli" enabled="false" />
+      <extension name="ncurses" enabled="false" />
+      <extension name="newrelic" enabled="false" />
+      <extension name="oauth" enabled="false" />
+      <extension name="oci8" enabled="false" />
+      <extension name="odbc" enabled="false" />
+      <extension name="pcntl" enabled="false" />
+      <extension name="pdflib" enabled="false" />
+      <extension name="pdo_ibm" enabled="false" />
+      <extension name="pdo_pgsql" enabled="false" />
+      <extension name="pgsql" enabled="false" />
+      <extension name="pspell" enabled="false" />
+      <extension name="pthreads" enabled="false" />
+      <extension name="radius" enabled="false" />
+      <extension name="rar" enabled="false" />
+      <extension name="recode" enabled="false" />
+      <extension name="rrd" enabled="false" />
+      <extension name="shmop" enabled="false" />
+      <extension name="snmp" enabled="false" />
+      <extension name="soap" enabled="false" />
+      <extension name="sockets" enabled="false" />
+      <extension name="sqlsrv" enabled="false" />
+      <extension name="ssh2" enabled="false" />
+      <extension name="suhosin" enabled="false" />
+      <extension name="svn" enabled="false" />
+      <extension name="sybase" enabled="false" />
+      <extension name="sysvmsg" enabled="false" />
+      <extension name="sysvsem" enabled="false" />
+      <extension name="sysvshm" enabled="false" />
+      <extension name="tidy" enabled="false" />
+      <extension name="v8js" enabled="false" />
+      <extension name="wddx" enabled="false" />
+      <extension name="win32service" enabled="false" />
+      <extension name="wincache" enabled="false" />
+      <extension name="xhprof" enabled="false" />
+      <extension name="xlswriter" enabled="false" />
+      <extension name="xmlrpc" enabled="false" />
+      <extension name="xsl" enabled="false" />
+      <extension name="zend" enabled="false" />
+      <extension name="zip" enabled="false" />
+      <extension name="zmq" enabled="false" />
+    </extensions>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/Classes/Components/RedirectToCorrectDimensionComponent.php
+++ b/Classes/Components/RedirectToCorrectDimensionComponent.php
@@ -10,8 +10,8 @@ namespace PunktDe\Mautic\Components;
 use Neos\Flow\Configuration\ConfigurationManager;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Http\Component\ComponentChain;
-use Neos\Flow\Http\Component\ComponentInterface;
-use Neos\Flow\Http\Component\ComponentContext;
+//use Neos\Flow\Http\Component\ComponentInterface;
+use Neos\Flow\Http\Component\ComponentContext ;
 use Neos\Flow\Http\Cookie;
 use Neos\Neos\Domain\Service\ConfigurationContentDimensionPresetSource;
 use Psr\Http\Message\RequestInterface;
@@ -21,7 +21,7 @@ use PunktDe\Mautic\Mautic\MauticConnector;
 use Neos\Neos\Routing;
 use PunktDe\Mautic\Mautic\MauticFrontendUri;
 
-class RedirectToCorrectDimensionComponent implements ComponentInterface
+class RedirectToCorrectDimensionComponent #implements ComponentInterface
 {
 
     /**

--- a/Classes/Components/RedirectToCorrectDimensionComponent.php
+++ b/Classes/Components/RedirectToCorrectDimensionComponent.php
@@ -239,7 +239,7 @@ class RedirectToCorrectDimensionComponent implements ComponentInterface
      */
     protected function mauticUserIsIdentifiedByCookie(ComponentContext $componentContext): bool
     {
-        $cookie = $this->getHttpRequestFromComponent($componentContext)->getCookie('mtc_id');
+        $cookie = $this->getHttpRequestFromComponent($componentContext)->getCookieParams()['mtc_id'];
         return $cookie === null ? false : true;
     }
 
@@ -250,11 +250,11 @@ class RedirectToCorrectDimensionComponent implements ComponentInterface
     protected function getMauticSegmentFromCookieIfAvailable(ComponentContext $componentContext): string
     {
         $httpRequest = $this->getHttpRequestFromComponent($componentContext);
-        $cookie = $httpRequest->getCookie('mautic_segment');
+        $cookie = $httpRequest->getCookieParams()['mautic_segment'];
         if ($cookie === null) {
             return '';
         }
-        return $cookie->getValue();
+        return $cookie;
     }
 
     /**
@@ -264,7 +264,7 @@ class RedirectToCorrectDimensionComponent implements ComponentInterface
     protected function getMauticUserId(ComponentContext $componentContext): int
     {
         $httpRequest = $this->getHttpRequestFromComponent($componentContext);
-        $cookie = $httpRequest->getCookie('mtc_id');
+        $cookie = $httpRequest->getCookieParams()['mtc_id'];
         return $cookie->getValue() !== '' ? (int)$cookie->getValue() : 0;
     }
 }

--- a/Classes/Finishers/MauticFormFinisher.php
+++ b/Classes/Finishers/MauticFormFinisher.php
@@ -1,0 +1,71 @@
+<?php
+declare(strict_types=1);
+
+namespace PunktDe\Mautic\Finishers;
+
+/***
+ *
+ * This file is part of the "Mautic" extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ *  (c) 2020 Florian Wessels <f.wessels@Leuchtfeuer.com>, Leuchtfeuer Digital Marketing
+ *
+ ***/
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Form\Core\Model\AbstractFinisher;
+use Neos\Form\Exception\FinisherException;
+use PunktDe\Mautic\Mautic\MauticConnector;
+
+class MauticFormFinisher extends AbstractFinisher
+{
+
+  /**
+   * @var array
+   */
+  protected $defaultOptions = [
+    'mauticFormId' => null,
+  ];
+
+  /**
+   * @Flow\Inject
+   * @var MauticConnector
+   */
+  protected $mauticConnector;
+
+  /**
+   * Executes this finisher
+   * @return void
+   * @throws \Mautic\Exception\ContextNotFoundException
+   * @throws FinisherException
+   * @see AbstractFinisher::execute()
+   */
+  protected function executeInternal(): void
+  {
+    $formDefinition = $this->finisherContext->getFormRuntime()->getFormDefinition()->getRenderingOptions();
+    $mauticId = !empty($this->parseOption('mauticFormId')) ? (int)$this->parseOption('mauticFormId') : $formDefinition['mauticFormId'];
+    $data = $this->get_data();
+    $this->mauticConnector->submitForm($mauticId, $data);
+  }
+
+  /**
+   * @return array
+   */
+  protected function get_data(): array
+  {
+    $optionArray = [];
+    $pages = $this->finisherContext->getFormRuntime()->getFormDefinition()->getPages();
+    foreach ($pages as $page) {
+      $renderables = $page->getRenderablesRecursively();
+      foreach ($renderables as $renderable) {
+        $properties = $renderable->getProperties();
+        if (array_key_exists('mauticAlias', $properties) && $properties['mauticAlias'] !== '') {
+          $optionArray[$properties['mauticAlias']] = $this->finisherContext->getFormValues()[$renderable->getIdentifier()];
+        }
+      }
+    }
+    return $optionArray;
+  }
+}

--- a/Classes/Finishers/MauticUpdateUserFinisher.php
+++ b/Classes/Finishers/MauticUpdateUserFinisher.php
@@ -64,7 +64,7 @@ class MauticUpdateUserFinisher extends AbstractFinisher
     }
 
     /**
-     * @return int
+     * @return ?string
      */
     protected function getMauticCookie(): ?string
     {

--- a/Classes/Finishers/MauticUpdateUserFinisher.php
+++ b/Classes/Finishers/MauticUpdateUserFinisher.php
@@ -51,10 +51,7 @@ class MauticUpdateUserFinisher extends AbstractFinisher
      */
     protected function mauticUserIsIdentifiedByCookie(): bool
     {
-        $request = $this->finisherContext->getFormRuntime()->getRequest()->getHttpRequest();
-        $cookie = $request->getCookie('mtc_id');
-
-        return $cookie === null ? false : true;
+        return $this->getMauticCookie() === null ? false : true;
     }
 
     /**
@@ -62,10 +59,17 @@ class MauticUpdateUserFinisher extends AbstractFinisher
      */
     protected function getUserIdFromCookie(): int
     {
-        $request = $this->finisherContext->getFormRuntime()->getRequest()->getHttpRequest();
-        $leadMauticId = $request->getCookie('mtc_id');
+        $leadMauticId = $this->getMauticCookie();
         return $leadMauticId->getValue() !== '' ? (int)$leadMauticId->getValue() : 0;
+    }
 
+    /**
+     * @return int
+     */
+    protected function getMauticCookie(): ?string
+    {
+        $request = $this->finisherContext->getFormRuntime()->getRequest()->getHttpRequest();
+        return $request->getCookieParams()['mtc_id'];
     }
 
     /**

--- a/Classes/Finishers/MauticUpdateUserFinisher.php
+++ b/Classes/Finishers/MauticUpdateUserFinisher.php
@@ -60,7 +60,7 @@ class MauticUpdateUserFinisher extends AbstractFinisher
     protected function getUserIdFromCookie(): int
     {
         $leadMauticId = $this->getMauticCookie();
-        return $leadMauticId->getValue() !== '' ? (int)$leadMauticId->getValue() : 0;
+        return $leadMauticId !== '' ? (int)$leadMauticId : 0;
     }
 
     /**
@@ -69,7 +69,8 @@ class MauticUpdateUserFinisher extends AbstractFinisher
     protected function getMauticCookie(): ?string
     {
         $request = $this->finisherContext->getFormRuntime()->getRequest()->getHttpRequest();
-        return $request->getCookieParams()['mtc_id'];
+        $cookies = $request->getCookieParams();
+        return isset($cookies['mtc_id']) ? $cookies['mtc_id'] : '';
     }
 
     /**

--- a/Classes/Finishers/MauticUpdateUserFinisher.php
+++ b/Classes/Finishers/MauticUpdateUserFinisher.php
@@ -96,7 +96,7 @@ class MauticUpdateUserFinisher extends AbstractFinisher
     protected function getUtmTags(): array
     {
         $request = $this->finisherContext->getFormRuntime()->getRequest()->getHttpRequest();
-        $params = $request->getArguments();
+        parse_str($request->getUri()->getQuery(), $params);
         $utmTags = [];
         foreach ($params as $paramName => $paramValue) {
             if (strpos($paramName, 'utm_') !== false) {

--- a/Classes/Mautic/MauticConnector.php
+++ b/Classes/Mautic/MauticConnector.php
@@ -109,5 +109,13 @@ class MauticConnector
         return $this->api->newApi('contacts', $this->auth, $this->mauticApiUrl);
     }
 
+    public function submitForm($id, $data){
+      $data['formId'] = $id;
+      $url = rtrim(trim(str_replace('/api','',$this->mauticApiUrl), '/')) . '/form/submit?formId=' . $id;
+      $send_form = new SendFormService();
+      $send_form->submitForm($url, $data);
+
+    }
+
 
 }

--- a/Classes/Mautic/MauticConnector.php
+++ b/Classes/Mautic/MauticConnector.php
@@ -77,6 +77,7 @@ class MauticConnector
      */
     public function sendUserUpdateToMauticAPI(int $userId, array $contactData): void
     {
+        die('OOK');
         $contactApi = $this->getContactsApi();
         $contactData['owner'] = '1';
         $contactApi->edit($userId, $contactData);

--- a/Classes/Mautic/MauticConnector.php
+++ b/Classes/Mautic/MauticConnector.php
@@ -77,7 +77,6 @@ class MauticConnector
      */
     public function sendUserUpdateToMauticAPI(int $userId, array $contactData): void
     {
-        die('OOK');
         $contactApi = $this->getContactsApi();
         $contactData['owner'] = '1';
         $contactApi->edit($userId, $contactData);

--- a/Classes/Mautic/SendFormService.php
+++ b/Classes/Mautic/SendFormService.php
@@ -1,0 +1,147 @@
+<?php
+declare(strict_types=1);
+
+namespace PunktDe\Mautic\Mautic;
+
+/***
+ *
+ * This file is part of the "Mautic" extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ *  (c) 2020 Florian Wessels <f.wessels@Leuchtfeuer.com>, Leuchtfeuer Digital Marketing
+ *
+ ***/
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Cookie\CookieJar;
+use GuzzleHttp\Cookie\SetCookie;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
+
+class SendFormService implements LoggerAwareInterface
+{
+  use LoggerAwareTrait;
+
+  public function submitForm(string $url, array $data): int
+  {
+    $client = new Client();
+    $multipart = [];
+
+    $headers = $this->makeHeaders();
+    $cookies = $this->makeCookies();
+    $this->makeMultipart($multipart, 'mauticform', $data);
+
+    if (\array_key_exists('mautic_device_id', $_COOKIE)) {
+      $multipart[] = [
+        'name' => 'mautic_device_id',
+        'contents' => $_COOKIE['mautic_device_id'],
+      ];
+    }
+
+    $result = null;
+    try {
+      $result = $client->post($url, [
+        'cookies' => $cookies,
+        'headers' => $headers,
+        'multipart' => $multipart,
+      ]);
+    } catch (\Exception $e) {
+      die(sprintf('%s: %s', $e->getCode(), $e->getMessage()));
+//      $this->logger->critical();
+
+      return 500;
+    }
+
+    $statusCode = $result->getStatusCode();
+
+    return (int)$statusCode;
+  }
+
+  private function makeHeaders(): array
+  {
+    $headers = [];
+    if (isset($_SERVER['HTTP_REFERER'])) {
+      $headers['Referer'] = $_SERVER['HTTP_REFERER'];
+    }
+    $ip = $this->getIpFromServer();
+    if ($ip !== '') {
+      $headers['X-Forwarded-For'] = $ip;
+      $headers['Client-Ip'] = $ip;
+    }
+
+    return $headers;
+  }
+
+  /**
+   * Guesses IP address from $_SERVER
+   */
+  public function getIpFromServer(): string
+  {
+    $ip = '';
+    $ipHolders = [
+      'HTTP_CLIENT_IP',
+      'HTTP_X_FORWARDED_FOR',
+      'HTTP_X_FORWARDED',
+      'HTTP_X_CLUSTER_CLIENT_IP',
+      'HTTP_FORWARDED_FOR',
+      'HTTP_FORWARDED',
+      'REMOTE_ADDR',
+    ];
+
+    foreach ($ipHolders as $key) {
+      if (!empty($_SERVER[$key])) {
+        $ip = $_SERVER[$key];
+        if (strpos($ip, ',') !== false) {
+          // Multiple IPs are present so use the last IP which should be
+          // the most reliable IP that last connected to the proxy
+          $ips = explode(',', $ip);
+          $ips = array_map('trim', $ips);
+          $ip = end($ips);
+        }
+        $ip = trim($ip);
+        break;
+      }
+    }
+
+    return $ip;
+  }
+
+  private function makeCookies(): CookieJar
+  {
+    $cookies = new CookieJar(true);
+    $this->addCookies($cookies, 'mtc_id');
+    $this->addCookies($cookies, 'mtc_sid');
+    $this->addCookies($cookies, 'mautic_device_id');
+    $this->addCookies($cookies, 'mautic_session_id');
+
+    return $cookies;
+  }
+
+  private function addCookies(CookieJar $cookies, string $cookieName)
+  {
+    if (\array_key_exists($cookieName, $_COOKIE)) {
+      $cookies->setCookie(new SetCookie([
+        'Name' => $cookieName,
+        'Value' => $_COOKIE[$cookieName],
+        'Domain' => $_SERVER['HTTP_HOST'],
+      ]));
+    }
+  }
+
+  private function makeMultipart(array &$multipart, string $path, array $data)
+  {
+    foreach ($data as $key => $value) {
+      $tempPath = $path . '[' . $key . ']';
+      if (is_array($value)) {
+        $this->makeMultipart($multipart, $tempPath, $value);
+      } else {
+        $multipart[] = [
+          'name' => $tempPath,
+          'contents' => $value,
+        ];
+      }
+    }
+  }
+}

--- a/Configuration/NodeTypes.Finishers.Mautic.yaml
+++ b/Configuration/NodeTypes.Finishers.Mautic.yaml
@@ -13,6 +13,31 @@
           position: 60
           icon: 'icon-paperclip'
 
+'PunktDe.Mautic.FormBuilder:MauticFormSubmit':
+  superTypes:
+    'Neos.Form.Builder:AbstractFinisher': true
+  ui:
+    label: 'Submit form to Mautic'
+    icon: 'check-square-o'
+    inspector:
+      groups:
+        'finisher':
+          icon: 'icheck-square-o'
+        'finisher-attachments':
+          label: i18n
+          position: 60
+          icon: 'icon-paperclip'
+  properties:
+    'mauticFormId':
+      type: string
+      ui:
+        label: 'Mautic form ID'
+        reloadIfChanged: false
+        inspector:
+          group: 'finisher'
+          editor: 'Neos.Neos/Inspector/Editors/TextFieldEditor'
+
+
 
 'Neos.Form.Builder:FormElement':
   superTypes:
@@ -32,6 +57,13 @@
       type: string
       ui:
         label: 'Mautic Identifier'
+        reloadIfChanged: false
+        inspector:
+          group: 'mauticSection'
+    'mauticAlias':
+      type: string
+      ui:
+        label: 'Mautic Form Field HTML name'
         reloadIfChanged: false
         inspector:
           group: 'mauticSection'

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -18,3 +18,6 @@ Neos:
           'PunktDe.Mautic:UpdateUser':
             implementationClassName: PunktDe\Mautic\Finishers\MauticUpdateUserFinisher
             options: { }
+          'PunktDe.Mautic:SendForm':
+            implementationClassName: PunktDe\Mautic\Finishers\MauticFormFinisher
+            options: { mauticId: integer }

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This Plugin enables the usage of Marketing Automation Tool Mautic together with 
 - [Enable API and HTTP basic auth](https://mautic.com/help/api-quick-start/). Optional: Be sure your Mautic installation 
 is running on HTTPS for the sake of security.
 - Skip this, if your website and Mautic are running on the same server:
-    - [Enable CORS](https://mautic.com/help/getting-started-mautic-cloud/#4), add your site to `valid domains`.
+- [Enable CORS](https://mautic.com/help/getting-started-mautic-cloud/#4), add your site to `valid domains`.
 
 ### Configure Plugin
 

--- a/Resources/Private/Fusion/MauticFormBuilder/MauticFormBuilder.fusion
+++ b/Resources/Private/Fusion/MauticFormBuilder/MauticFormBuilder.fusion
@@ -1,3 +1,7 @@
 prototype(PunktDe.Mautic.FormBuilder:MauticForm.Definition) < prototype(Neos.Form.Builder:Finisher.Definition) {
     formElementType = 'PunktDe.Mautic:UpdateUser'
 }
+
+prototype(PunktDe.Mautic.FormBuilder:MauticFormSubmit.Definition) < prototype(Neos.Form.Builder:Finisher.Definition) {
+    formElementType = 'PunktDe.Mautic:SendForm'
+}

--- a/composer.json
+++ b/composer.json
@@ -3,11 +3,12 @@
     "type": "neos-package",
     "name": "punktde/mautic",
     "license": "MIT",
-    "version": "1.1",
+    "version": "1.2",
     "require": {
         "neos/neos": ">=5.0",
         "neos/form-builder": ">=2.0",
-        "mautic/api-library": ">=2.0.0"
+        "mautic/api-library": ">=2.0.0",
+        "guzzlehttp/guzzle": "^7.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,6 @@
     "version": "1.1",
     "require": {
         "neos/neos": "^5.0",
-        "neos/form-builder": "^2.0",
         "mautic/api-library": "^2.0.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -5,9 +5,9 @@
     "license": "MIT",
     "version": "1.1",
     "require": {
-        "neos/neos": "^5.0",
-        "neos/form-builder": "^2.0",
-        "mautic/api-library": "^2.0.0"
+        "neos/neos": ">=5.0",
+        "neos/form-builder": ">=2.0",
+        "mautic/api-library": ">=2.0.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
     "version": "1.1",
     "require": {
         "neos/neos": "^5.0",
+        "neos/form-builder": "^2.0",
         "mautic/api-library": "^2.0.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -3,8 +3,10 @@
     "type": "neos-package",
     "name": "punktde/mautic",
     "license": "MIT",
+    "version": "1.1",
     "require": {
-        "neos/neos": "^4.0",
+        "neos/neos": "^5.0",
+        "neos/form-builder": "^2.0",
         "mautic/api-library": "^2.0.0"
     },
     "autoload": {


### PR DESCRIPTION
As the cookie methods were removed from request, accessing cookies must be done in a more low-level way. 

It seems this way it works. Also I have added dependency to neos/form-builder because in the Configuration/NodeTypes.Finishers.Mautic.yaml it has defined super type from the builder. 